### PR TITLE
SRE-2497 Add vars to use ephemeral storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -583,21 +583,10 @@ resource "aws_ecs_task_definition" "atlantis" {
 
   container_definitions = local.container_definitions
 
-  dynamic "volume" {
-    for_each = var.ecs_efs_volume != {} ? [var.ecs_efs_volume] : []
-
+  dynamic "ephemeral_storage" {
+    for_each = var.enable_ephemeral_storage ? [1] : []
     content {
-      name = "${var.name}-data"
-      efs_volume_configuration {
-        file_system_id          = volume.value["file_system_id"]
-        root_directory          = can(volume.value["root_directory"]) ? volume.value["root_directory"] : null
-        transit_encryption      = can(volume.value["transit_encryption"]) ? volume.value["transit_encryption"] : null
-        transit_encryption_port = can(volume.value["transit_encryption_port"]) ? volume.value["transit_encryption_port"] : null
-        authorization_config {
-          access_point_id = can(volume.value["access_point_id"]) ? volume.value["access_point_id"] : null
-          iam             = can(volume.value["iam"]) ? volume.value["iam"] : "DISABLED"
-        }
-      }
+      size_in_gib = var.ephemeral_storage_size_in_gib
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -586,7 +586,7 @@ resource "aws_ecs_task_definition" "atlantis" {
   dynamic "ephemeral_storage" {
     for_each = var.enable_ephemeral_storage ? [1] : []
     content {
-      size_in_gib = var.ephemeral_storage_size_in_gib
+      size_in_gib = var.ephemeral_storage_size
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -602,11 +602,6 @@ variable "enable_ecs_managed_tags" {
   default     = false
 }
 
-variable "ecs_efs_volume" {
-  description = "Map of EFS Volume Configuration Arguments.  See https://www.terraform.io/docs/providers/aws/r/ecs_task_definition#efs-volume-configuration-arguments"
-  type        = any
-  default     = {}
-}
 variable "use_ecs_old_arn_format" {
   description = "A flag to enable/disable tagging the ecs resources that require the new longer arn format"
   type        = bool
@@ -623,4 +618,20 @@ variable "ecs_service_enable_execute_command" {
   description = "Enable ECS exec for the service. This can be used to allow interactive sessions and commands to be executed in the container"
   type        = bool
   default     = true
+}
+
+variable "enable_ephemeral_storage" {
+  description = "Enable to use Fargate Ephermal Storage"
+  type = bool
+  default = false
+}
+variable "ephemeral_storage_size" {
+  description = "Size of Ephemeral Storage in GiB"
+  type = number
+  default = 21
+
+  validation {
+    condition = var.ephemeral_storage_size >= 21 && var.ephemeral_storage_size <= 200
+    error_message = "The minimum supported value is 21 GiB and the maximum supported value is 200 GiB."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -622,16 +622,16 @@ variable "ecs_service_enable_execute_command" {
 
 variable "enable_ephemeral_storage" {
   description = "Enable to use Fargate Ephermal Storage"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 variable "ephemeral_storage_size" {
   description = "Size of Ephemeral Storage in GiB"
-  type = number
-  default = 21
+  type        = number
+  default     = 21
 
   validation {
-    condition = var.ephemeral_storage_size >= 21 && var.ephemeral_storage_size <= 200
+    condition     = var.ephemeral_storage_size >= 21 && var.ephemeral_storage_size <= 200
     error_message = "The minimum supported value is 21 GiB and the maximum supported value is 200 GiB."
   }
 }


### PR DESCRIPTION
This change removes the EFS functionality and adds the ability to enable Ephermeral Storage in Fargate.
